### PR TITLE
Split loop() function

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -299,68 +299,76 @@ uint16_t PubSubClient::readPacket(uint8_t* lengthLength) {
     return len;
 }
 
-boolean PubSubClient::loop() {
-    if (connected()) {
-        unsigned long t = millis();
-        if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
-            if (pingOutstanding) {
-                this->_state = MQTT_CONNECTION_TIMEOUT;
-                _client->stop();
-                return false;
-            } else {
-                buffer[0] = MQTTPINGREQ;
+boolean PubSubClient::ping() {
+    t = millis();
+    if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
+        if (pingOutstanding) {
+            this->_state = MQTT_CONNECTION_TIMEOUT;
+            _client->stop();
+            return false;
+        } else {
+            buffer[0] = MQTTPINGREQ;
+            buffer[1] = 0;
+            _client->write(buffer,2);
+            lastOutActivity = t;
+            lastInActivity = t;
+            pingOutstanding = true;
+        }
+    }
+}
+
+boolean PubSubClient::read() {
+    if (_client->available()) {
+        uint8_t llen;
+        uint16_t len = readPacket(&llen);
+        uint16_t msgId = 0;
+        uint8_t *payload;
+        if (len > 0) {
+            lastInActivity = t;
+            uint8_t type = buffer[0]&0xF0;
+            if (type == MQTTPUBLISH) {
+                if (callback) {
+                    uint16_t tl = (buffer[llen+1]<<8)+buffer[llen+2]; /* topic length in bytes */
+                    memmove(buffer+llen+2,buffer+llen+3,tl); /* move topic inside buffer 1 byte to front */
+                    buffer[llen+2+tl] = 0; /* end the topic as a 'C' string with \x00 */
+                    char *topic = (char*) buffer+llen+2;
+                    // msgId only present for QOS>0
+                    if ((buffer[0]&0x06) == MQTTQOS1) {
+                        msgId = (buffer[llen+3+tl]<<8)+buffer[llen+3+tl+1];
+                        payload = buffer+llen+3+tl+2;
+                        callback(topic,payload,len-llen-3-tl-2);
+
+                        buffer[0] = MQTTPUBACK;
+                        buffer[1] = 2;
+                        buffer[2] = (msgId >> 8);
+                        buffer[3] = (msgId & 0xFF);
+                        _client->write(buffer,4);
+                        lastOutActivity = t;
+
+                    } else {
+                        payload = buffer+llen+3+tl;
+                        callback(topic,payload,len-llen-3-tl);
+                    }
+                }
+            } else if (type == MQTTPINGREQ) {
+                buffer[0] = MQTTPINGRESP;
                 buffer[1] = 0;
                 _client->write(buffer,2);
-                lastOutActivity = t;
-                lastInActivity = t;
-                pingOutstanding = true;
+            } else if (type == MQTTPINGRESP) {
+                pingOutstanding = false;
             }
+        } else if (!connected()) {
+            // readPacket has closed the connection
+            return false;
         }
-        if (_client->available()) {
-            uint8_t llen;
-            uint16_t len = readPacket(&llen);
-            uint16_t msgId = 0;
-            uint8_t *payload;
-            if (len > 0) {
-                lastInActivity = t;
-                uint8_t type = buffer[0]&0xF0;
-                if (type == MQTTPUBLISH) {
-                    if (callback) {
-                        uint16_t tl = (buffer[llen+1]<<8)+buffer[llen+2]; /* topic length in bytes */
-                        memmove(buffer+llen+2,buffer+llen+3,tl); /* move topic inside buffer 1 byte to front */
-                        buffer[llen+2+tl] = 0; /* end the topic as a 'C' string with \x00 */
-                        char *topic = (char*) buffer+llen+2;
-                        // msgId only present for QOS>0
-                        if ((buffer[0]&0x06) == MQTTQOS1) {
-                            msgId = (buffer[llen+3+tl]<<8)+buffer[llen+3+tl+1];
-                            payload = buffer+llen+3+tl+2;
-                            callback(topic,payload,len-llen-3-tl-2);
+    }
+    return true;
+}
 
-                            buffer[0] = MQTTPUBACK;
-                            buffer[1] = 2;
-                            buffer[2] = (msgId >> 8);
-                            buffer[3] = (msgId & 0xFF);
-                            _client->write(buffer,4);
-                            lastOutActivity = t;
-
-                        } else {
-                            payload = buffer+llen+3+tl;
-                            callback(topic,payload,len-llen-3-tl);
-                        }
-                    }
-                } else if (type == MQTTPINGREQ) {
-                    buffer[0] = MQTTPINGRESP;
-                    buffer[1] = 0;
-                    _client->write(buffer,2);
-                } else if (type == MQTTPINGRESP) {
-                    pingOutstanding = false;
-                }
-            } else if (!connected()) {
-                // readPacket has closed the connection
-                return false;
-            }
-        }
-        return true;
+boolean PubSubClient::loop() {
+    if (connected()) {
+        if(~_client->read()) return false;
+        return _client->read();
     }
     return false;
 }

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -92,7 +92,7 @@ private:
    uint16_t nextMsgId;
    unsigned long lastOutActivity;
    unsigned long lastInActivity;
-   bool pingOutstanding;
+   unsigned long t;
    MQTT_CALLBACK_SIGNATURE;
    uint16_t readPacket(uint8_t*);
    boolean readByte(uint8_t * result);
@@ -132,6 +132,8 @@ public:
    PubSubClient& setClient(Client& client);
    PubSubClient& setStream(Stream& stream);
 
+   bool pingOutstanding;
+   
    boolean connect(const char* id);
    boolean connect(const char* id, const char* user, const char* pass);
    boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
@@ -164,6 +166,8 @@ public:
    boolean subscribe(const char* topic);
    boolean subscribe(const char* topic, uint8_t qos);
    boolean unsubscribe(const char* topic);
+   boolean read();
+   boolean ping();
    boolean loop();
    boolean connected();
    int state();


### PR DESCRIPTION
The loop() function was split into two parts, ping and read, for integration with systems that allow interrupt driven networking. This allows the user to use event driven control to control the ping timing and wait for an interrupt to occur on the network interface adapter.